### PR TITLE
mailhogを導入し、パスワードリセットが可能

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,3 +30,7 @@ services:
     volumes:
       - ../src:/work/backend
     depends_on: ["app"]
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - 8025:8025


### PR DESCRIPTION
## What's Changed
- docker-compose.ymlにmailhogを導入した
  - パスワードリセットが可能になった 

## Linked Issues
#11 

## Operation Check with Screenshots
### localhost:8025でmailhogが開ける
<img width="1512" alt="スクリーンショット 2022-08-23 16 27 00" src="https://user-images.githubusercontent.com/74942852/186097541-e05c2009-22c1-4f6c-9300-f3708fd9d7e8.png">

### パスワードリセットが可能
<img width="1512" alt="スクリーンショット 2022-08-23 16 27 49" src="https://user-images.githubusercontent.com/74942852/186097741-d7dd318c-e0bb-4695-b3fd-cc283690d3ee.png">